### PR TITLE
Appended qnetmap_polyline.cpp/.h to libqnetmap qmake project

### DIFF
--- a/lib/src/qnetmap_polyline.cpp
+++ b/lib/src/qnetmap_polyline.cpp
@@ -776,12 +776,12 @@ namespace qnetmap
                K21 = K2 - K1;
                try {
                   Bias = (T.x() * K12.y() - T.y() * K12.x()) / (T.y() * K21.x() - T.x() * K21.y());
-                  if(abs(Bias) > 1.) Bias = sgn(Bias);
-                  if(abs(K12.x() + Bias * K21.x()) > abs(K12.y() + Bias * K21.y()))
+                  if(fabs(Bias) > 1.) Bias = sgn(Bias);
+                  if(fabs(K12.x() + Bias * K21.x()) > fabs(K12.y() + Bias * K21.y()))
                        Tension = 1. - T.x() / (K12.x() + Bias * K21.x());
                   else Tension = 1. - T.y() / (K12.y() + Bias * K21.y());
-                  Tension = sgn(Tension) * std::max(abs(1. - T.x() / (K12.x() + Bias * K21.x())), abs(1. - T.y() / (K12.y() + Bias * K21.y())));
-                  if(abs(Tension) > 1.) Tension = sgn(Tension);
+                  Tension = sgn(Tension) * std::max(fabs(1. - T.x() / (K12.x() + Bias * K21.x())), fabs(1. - T.y() / (K12.y() + Bias * K21.y())));
+                  if(fabs(Tension) > 1.) Tension = sgn(Tension);
                }
                catch(...) {}
                // check the tangent minimum length
@@ -803,7 +803,7 @@ namespace qnetmap
                case PolyLineInputPoint:
                   try {
                      T = CurrentPoint - Coordinate_;
-                     if(abs(K1.x() - K2.x()) > abs(K1.y() - K2.y()))
+                     if(fabs(K1.x() - K2.x()) > fabs(K1.y() - K2.y()))
                           Continuity = (T.x() - K1.x() - K2.x()) / (K1.x() - K2.x());
                      else Continuity = (T.y() - K1.y() - K2.y()) / (K1.y() - K2.y());
                   }
@@ -812,7 +812,7 @@ namespace qnetmap
                case PolyLineOutputPoint:
                   try {
                      T = - CurrentPoint + Coordinate_;
-                     if(abs(K2.x() - K1.x()) > abs(K2.y() - K1.y()))
+                     if(fabs(K2.x() - K1.x()) > fabs(K2.y() - K1.y()))
                           Continuity = (T.x() - K1.x() - K2.x()) / (K2.x() - K1.x());
                      else Continuity = (T.y() - K1.y() - K2.y()) / (K2.y() - K1.y());
                   }
@@ -948,7 +948,7 @@ namespace qnetmap
    //-------------------------------------------------------------------------------------
    void TPolyLine::TPolyLinePoint::setTension( const qreal Tension_ /*= 0*/ )
    {
-      if(abs(Tension_) > 1.) m_Tension = sgn(Tension_);
+      if(fabs(Tension_) > 1.) m_Tension = sgn(Tension_);
       else                   m_Tension = Tension_;
       m_Factors = TFactors(m_Tension, m_Continuity, m_Bias);
    }
@@ -956,7 +956,7 @@ namespace qnetmap
    //-------------------------------------------------------------------------------------
    void TPolyLine::TPolyLinePoint::setContinuity( const qreal Continuity_ /*= 0*/ )
    {
-      if(abs(Continuity_) > 0.9) m_Continuity = sgn(Continuity_) * 0.9; // 0.9 is special value that cuts off the boundary effects
+      if(fabs(Continuity_) > 0.9) m_Continuity = sgn(Continuity_) * 0.9; // 0.9 is special value that cuts off the boundary effects
       else                       m_Continuity = Continuity_;
       m_Factors = TFactors(m_Tension, m_Continuity, m_Bias);
    }
@@ -964,7 +964,7 @@ namespace qnetmap
    //-------------------------------------------------------------------------------------
    void TPolyLine::TPolyLinePoint::setBias( const qreal Bias_ /*= 0*/ )
    {
-      if(abs(Bias_) > 1.) m_Bias = sgn(Bias_);
+      if(fabs(Bias_) > 1.) m_Bias = sgn(Bias_);
       else                m_Bias = Bias_;
       m_Factors = TFactors(m_Tension, m_Continuity, m_Bias);
    }

--- a/projects/qmake/lib/lib.pri
+++ b/projects/qmake/lib/lib.pri
@@ -30,6 +30,7 @@ HEADERS += ../../../lib/src/qnetmap_arrowpoint.h \
     ../../../lib/src/qnetmap_pngimage.h \
     ../../../lib/src/qnetmap_point.h \
     ../../../lib/src/qnetmap_polygon.h \
+    ../../../lib/src/qnetmap_polyline.h \
     ../../../lib/src/qnetmap_rastermap.h \
     ../../../lib/src/qnetmap_rastermapadapter.h \
     ../../../lib/src/qnetmap_rastermapsdialog.h \
@@ -76,6 +77,7 @@ SOURCES += ../../../lib/src/qnetmap_arrowpoint.cpp \
     ../../../lib/src/qnetmap_pngimage.cpp \
     ../../../lib/src/qnetmap_point.cpp \
     ../../../lib/src/qnetmap_polygon.cpp \
+    ../../../lib/src/qnetmap_polyline.cpp \
     ../../../lib/src/qnetmap_rastermap.cpp \
     ../../../lib/src/qnetmap_rastermapadapter.cpp \
     ../../../lib/src/qnetmap_rastermapsdialog.cpp \


### PR DESCRIPTION
Appended qnetmap_polyline.cpp/.h to libqnetmap qmake project and fixed ambigous abs() calls.
The TPolyLine class exists in Visual Studio solution, but nonexist in qmake project. I synchronize projects.
